### PR TITLE
fix(readme): fix to valid example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import (
 func main() {
 	items := []string{"hello", "world", "foo", "bar"}
 
-	f, _ := fzf.New()
+	f, err := fzf.New()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The example cannot be compiled. I think it needs to use `err` instead `_`.